### PR TITLE
Implement simple scraper for known sites

### DIFF
--- a/backend/app/scrapers/basic.py
+++ b/backend/app/scrapers/basic.py
@@ -1,35 +1,78 @@
 # app/scrapers/basic.py
 
-import requests
-from bs4 import BeautifulSoup
+import logging
+from datetime import datetime
 from typing import List, Dict, Union
 
-def scrape(url: str) -> Union[List[Dict], Dict]:
-    """
-    Devuelve:
-      - Una lista de dicts con keys: price, date, shop, city.
-      - Si no encuentra datos, devuelve {"price": "#"} como bandera.
-    """
-    resp = requests.get(url, timeout=10)
-    resp.raise_for_status()
-    soup = BeautifulSoup(resp.text, "html.parser")
+import requests
+from bs4 import BeautifulSoup
 
+def _parse_mercadolibre(soup: BeautifulSoup) -> List[Dict]:
     results: List[Dict] = []
-    # ————— Aquí va tu lógica existente de scraping —————
-    # for element in soup.select("..."):
-    #     price = ...
-    #     date  = ...
-    #     shop  = ...
-    #     city  = ...
-    #     results.append({
-    #         "price": price,
-    #         "date": date,
-    #         "shop": shop,
-    #         "city": city,
-    #     })
+    for card in soup.select("li.ui-search-layout__item"):
+        price_el = card.select_one("span.andes-money-amount__fraction")
+        if not price_el:
+            continue
+        city_el = card.select_one(
+            "span.ui-search-item__group__element.ui-search-item__location"
+        )
+        shop_el = card.select_one("p.ui-search-official-store-label__text")
+        results.append(
+            {
+                "price": price_el.get_text(strip=True),
+                "date": datetime.utcnow().isoformat(),
+                "shop": shop_el.get_text(strip=True) if shop_el else "MercadoLibre",
+                "city": city_el.get_text(strip=True) if city_el else "",
+            }
+        )
+    return results
 
-    # Si no obtuvimos nada, devolvemos la bandera
+
+def _parse_fravega(soup: BeautifulSoup) -> List[Dict]:
+    results: List[Dict] = []
+    for card in soup.select("div.card-product"):  # general card selector
+        price_el = card.select_one(".card-product-price")
+        if not price_el:
+            continue
+        results.append(
+            {
+                "price": price_el.get_text(strip=True),
+                "date": datetime.utcnow().isoformat(),
+                "shop": "Frávega",
+                "city": "",
+            }
+        )
+    return results
+
+
+def scrape(url: str) -> Union[List[Dict], Dict]:
+    """Extrae precios de la URL indicada.
+
+    Devuelve una lista de dicts con keys: ``price``, ``date``, ``shop`` y
+    ``city``. Si no se pudo extraer un precio devuelve ``{"price": "#"}``.
+    """
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+    except Exception as exc:
+        logging.exception("Network error while scraping %s", url)
+        return {"price": "#"}
+
+    try:
+        soup = BeautifulSoup(resp.text, "html.parser")
+        if "mercadolibre" in url.lower():
+            results = _parse_mercadolibre(soup)
+        elif "fravega" in url.lower():
+            results = _parse_fravega(soup)
+        else:
+            logging.warning("Unknown site for URL: %s", url)
+            results = []
+    except Exception as exc:
+        logging.exception("Parsing error for %s", url)
+        return {"price": "#"}
+
     if not results:
         return {"price": "#"}
 
     return results
+


### PR DESCRIPTION
## Summary
- implement MercadoLibre/Frávega scraping in `basic.py`
- add logging and error handling

## Testing
- `bash scripts/test.sh` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683e87dac083238811bfafdb14ba79