### PR TITLE
Replace OpenAI site selection with heuristics

### DIFF
--- a/backend/app/api/v1/price.py
+++ b/backend/app/api/v1/price.py
@@ -21,6 +21,7 @@ async def get_price(body: Dict[str, Any]):
     if not product:
         raise HTTPException(status_code=400, detail="Falta el parámetro product")
 
+    # Determinar la URL para scrapear de forma local
     url = get_price_url(product)
 
     start = time.time()

--- a/backend/app/services/openai_helper.py
+++ b/backend/app/services/openai_helper.py
@@ -3,21 +3,39 @@
 # backend/app/services/openai_helper.py
 
 import os
-from openai import OpenAI, ChatCompletion
+from openai import OpenAI
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)
 
+# Palabras clave para identificar productos electrodomésticos.
+ELECTRO_KEYWORDS = {
+    "heladera",
+    "lavadora",
+    "lavarropas",
+    "microondas",
+    "cocina",
+    "freezer",
+    "licuadora",
+    "secadora",
+    "aspiradora",
+    "plancha",
+    "aire acondicionado",
+}
+
 def get_price_url(product: str) -> str:
-    prompt = (
-        f"Dame una URL confiable para scrapear el mejor precio de “{product}” "
-        "(MercadoLibre, Frávega, etc.). Responde solo con la URL."
-    )
-    resp = client.chat.completions.create(
-        model="gpt-3.5-turbo",
-        messages=[{"role":"user", "content": prompt}],
-    )
-    return resp.choices[0].message.content.strip()
+    """Return a scraping URL for ``product`` using local heuristics."""
+
+    query = product.strip()
+    query_lower = query.lower()
+
+    if any(keyword in query_lower for keyword in ELECTRO_KEYWORDS):
+        search = query.replace(" ", "+")
+        return f"https://www.tupy.com.py/search?q={search}"
+
+    # Default to MercadoLibre search
+    search = query.replace(" ", "-")
+    return f"https://listado.mercadolibre.com.py/{search}"
 
 def format_price_msg(product: str, data: dict) -> list[str]:
     prompt = (

--- a/backend/app/tests/api/routes/test_price.py
+++ b/backend/app/tests/api/routes/test_price.py
@@ -9,7 +9,6 @@ def test_price_returns_messages(client: TestClient) -> None:
     fake_msgs = ["Precio 1", "Compra ya"]
     fake_data = [{"price": "1", "date": "2024-01-01", "shop": "Shop", "city": "Asu"}]
     with (
-        patch("app.services.openai_helper.get_price_url", return_value="http://example.com"),
         patch("app.services.openai_helper.format_price_msg", return_value=fake_msgs),
         patch("app.scrapers.basic.scrape", return_value=fake_data),
         patch("app.scrapers.basic.requests.get"),
@@ -21,7 +20,6 @@ def test_price_returns_messages(client: TestClient) -> None:
 
 def test_price_no_data(client: TestClient) -> None:
     with (
-        patch("app.services.openai_helper.get_price_url", return_value="http://example.com"),
         patch("app.scrapers.basic.scrape", return_value={"price": "#"}),
         patch("app.scrapers.basic.requests.get"),
     ):

--- a/backend/app/tests/services/test_openai_helper.py
+++ b/backend/app/tests/services/test_openai_helper.py
@@ -1,0 +1,13 @@
+import pytest
+
+from app.services.openai_helper import get_price_url
+
+
+def test_get_price_url_electrodomestic() -> None:
+    url = get_price_url("lavadora whirlpool")
+    assert "tupy.com.py" in url
+
+
+def test_get_price_url_default() -> None:
+    url = get_price_url("iphone 13")
+    assert "mercadolibre" in url


### PR DESCRIPTION
## Summary
- update `openai_helper.get_price_url` with local keyword heuristics
- use local URL selection in price endpoint
- adjust price endpoint tests
- add unit tests for the new helper logic

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6868458b96808323ae6ad6982cfb1a82