### PR TITLE
Add Tupy price scraper

### DIFF
--- a/backend/app/scrapers/basic.py
+++ b/backend/app/scrapers/basic.py
@@ -45,6 +45,23 @@ def _parse_fravega(soup: BeautifulSoup) -> List[Dict]:
     return results
 
 
+def _parse_tupy(soup: BeautifulSoup) -> List[Dict]:
+    results: List[Dict] = []
+    for card in soup.select("div.product-item"):
+        price_el = card.select_one(".product-price")
+        if not price_el:
+            continue
+        results.append(
+            {
+                "price": price_el.get_text(strip=True),
+                "date": datetime.utcnow().isoformat(),
+                "shop": "Tupy",
+                "city": "",
+            }
+        )
+    return results
+
+
 def scrape(url: str) -> Union[List[Dict], Dict]:
     """Extrae precios de la URL indicada.
 
@@ -64,6 +81,8 @@ def scrape(url: str) -> Union[List[Dict], Dict]:
             results = _parse_mercadolibre(soup)
         elif "fravega" in url.lower():
             results = _parse_fravega(soup)
+        elif "tupy.com.py" in url.lower():
+            results = _parse_tupy(soup)
         else:
             logging.warning("Unknown site for URL: %s", url)
             results = []

--- a/backend/app/services/openai_helper.py
+++ b/backend/app/services/openai_helper.py
@@ -8,7 +8,22 @@ from openai import OpenAI, ChatCompletion
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)
 
+ELECTRO_KEYWORDS = [
+    "heladera",
+    "lavarropa",
+    "microondas",
+    "cocina",
+    "licuadora",
+    "plancha",
+]
+
+
 def get_price_url(product: str) -> str:
+    lower = product.lower()
+    if any(word in lower for word in ELECTRO_KEYWORDS):
+        query = product.replace(" ", "+")
+        return f"https://www.tupy.com.py/buscar?q={query}"
+
     prompt = (
         f"Dame una URL confiable para scrapear el mejor precio de “{product}” "
         "(MercadoLibre, Frávega, etc.). Responde solo con la URL."

--- a/backend/app/tests/scrapers/test_tupy.py
+++ b/backend/app/tests/scrapers/test_tupy.py
@@ -1,0 +1,21 @@
+from bs4 import BeautifulSoup
+
+from app.scrapers.basic import _parse_tupy
+
+
+HTML = """
+<div class="product-item">
+  <span class="product-price">1.000</span>
+</div>
+<div class="product-item">
+  <span class="product-price">2.000</span>
+</div>
+"""
+
+
+def test_parse_tupy_extracts_prices() -> None:
+    soup = BeautifulSoup(HTML, "html.parser")
+    results = _parse_tupy(soup)
+    assert len(results) == 2
+    assert results[0]["price"] == "1.000"
+    assert all(r["shop"] == "Tupy" for r in results)


### PR DESCRIPTION
## Summary
- parse Tupy website in the basic scraper
- route Tupy URLs to the new parser
- pick Tupy directly for electrodomestic searches
- test the Tupy parser

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68684592ab6483239a7942d07ee98581