### PR TITLE
Format with ruff

### DIFF
--- a/backend/app/api/v1/price.py
+++ b/backend/app/api/v1/price.py
@@ -1,18 +1,19 @@
 # app/api/v1/price.py
 
-import time
-import logging
 import asyncio
-from fastapi import APIRouter, HTTPException
-from typing import Any, Dict, List, Union
+import logging
+import time
+from typing import Any
 
-from app.services.openai_helper import get_price_url, format_price_msg
+from fastapi import APIRouter, HTTPException
+
 from app.scrapers.basic import scrape
+from app.services.openai_helper import format_price_msg, get_price_url
 
 router = APIRouter()
 
-@router.post("/price", response_model=Dict[str, Any])
-async def get_price(body: Dict[str, Any]):
+@router.post("/price", response_model=dict[str, Any])
+async def get_price(body: dict[str, Any]):
     """
     Recibe {"product": "<nombre>"}.
     Devuelve {"messages": [...]} o {"messages": [], "error":"no_data"}.
@@ -28,7 +29,7 @@ async def get_price(body: Dict[str, Any]):
 
     try:
         # Ejecutamos el scraper en un hilo para no bloquear el event loop
-        data: Union[List[Dict], Dict] = await asyncio.to_thread(scrape, url)
+        data: list[dict] | dict = await asyncio.to_thread(scrape, url)
     except Exception as e:
         logging.exception("Error interno en scraper")
         # Si el scraper falla, devolvemos rápidamente sin bloquear cliente
@@ -44,5 +45,5 @@ async def get_price(body: Dict[str, Any]):
         logging.error("Scraper devolvió formato inesperado: %r", data)
         raise HTTPException(status_code=500, detail="Formato de datos inesperado")
 
-    messages: List[str] = format_price_msg(product, data)
+    messages: list[str] = format_price_msg(product, data)
     return {"messages": messages}

--- a/backend/app/services/openai_helper.py
+++ b/backend/app/services/openai_helper.py
@@ -3,7 +3,8 @@
 # backend/app/services/openai_helper.py
 
 import os
-from openai import OpenAI, ChatCompletion
+
+from openai import OpenAI
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)


### PR DESCRIPTION
## Summary
- format backend with ruff
- adopt builtin generic syntax for price endpoint
- clean up OpenAI import

## Testing
- `ruff check --fix backend/app/api/v1/price.py backend/app/services/openai_helper.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6868489de17083238032295981754040