### PR TITLE
Add openai dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydantic-settings<3.0.0,>=2.2.1",
     "sentry-sdk[fastapi]<2.0.0,>=1.40.6",
     "pyjwt<3.0.0,>=2.8.0",
+    "openai>=1.15.0",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- add the `openai` package to backend dependencies

## Testing
- `uv pip install -e .` *(fails: failed to fetch packages)*
- `pytest --maxfail=1 --collect-only` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686848a2416c83238db0163a6795f850