### PR TITLE
Add unit tests for OpenAI helper

### DIFF
--- a/backend/app/tests/services/test_openai_helper.py
+++ b/backend/app/tests/services/test_openai_helper.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from app.services.openai_helper import format_price_msg, get_price_url
+
+
+def test_get_price_url_returns_stripped_url() -> None:
+    url = "https://example.com/product"
+    mock_resp = MagicMock()
+    mock_choice = MagicMock()
+    mock_choice.message.content = f"  {url}\n"
+    mock_resp.choices = [mock_choice]
+    client_mock = MagicMock()
+    client_mock.chat.completions.create.return_value = mock_resp
+
+    with patch("app.services.openai_helper.client", client_mock):
+        result = get_price_url("PlayStation")
+
+    assert result == url
+    client_mock.chat.completions.create.assert_called_once()
+
+
+def test_format_price_msg_splits_lines() -> None:
+    message = "Precio: 100\nRecomendado.\n"
+    mock_resp = MagicMock()
+    mock_choice = MagicMock()
+    mock_choice.message.content = message
+    mock_resp.choices = [mock_choice]
+    client_mock = MagicMock()
+    client_mock.chat.completions.create.return_value = mock_resp
+
+    with patch("app.services.openai_helper.client", client_mock):
+        result = format_price_msg("PlayStation", {"price": 100})
+
+    assert result == ["Precio: 100", "Recomendado."]
+    client_mock.chat.completions.create.assert_called_once()


### PR DESCRIPTION
## Summary
- add tests for service functions in `openai_helper`
- mock the OpenAI client to avoid real API calls

## Testing
- `ruff check backend/app/tests/services/test_openai_helper.py`
- `pytest backend/app/tests/services/test_openai_helper.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68684d4ac46483239476b1226dad439d