### PR TITLE
Add OPENAI_API_KEY handling

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,8 @@ BACKEND_CORS_ORIGINS="http://localhost,http://localhost:5173,https://localhost,h
 SECRET_KEY=changethis
 FIRST_SUPERUSER=admin@example.com
 FIRST_SUPERUSER_PASSWORD=changethis
+# OpenAI API key (required for OpenAI features)
+OPENAI_API_KEY=
 
 # Emails
 SMTP_HOST=

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Before deploying it, make sure you change at least the values for:
 - `SECRET_KEY`
 - `FIRST_SUPERUSER_PASSWORD`
 - `POSTGRES_PASSWORD`
+- `OPENAI_API_KEY`
 
 You can (and should) pass these as environment variables from secrets.
 
@@ -211,6 +212,7 @@ The input variables, with their default values (some auto generated) are:
 - `emails_from_email`: (default: `"info@example.com"`) The email account to send emails from, you can set it later in .env.
 - `postgres_password`: (default: `"changethis"`) The password for the PostgreSQL database, stored in .env, you can generate one with the method above.
 - `sentry_dsn`: (default: "") The DSN for Sentry, if you are using it, you can set it later in .env.
+- `openai_api_key`: (default: "") The API key for OpenAI. Required for features that interact with OpenAI.
 
 ## Backend Development
 

--- a/backend/app/services/openai_helper.py
+++ b/backend/app/services/openai_helper.py
@@ -1,9 +1,18 @@
 # backend/app/services/openai_helper.py
 
 import os
+import logging
 from openai import OpenAI, ChatCompletion
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    message = "OPENAI_API_KEY environment variable is not set"
+    logger.error(message)
+    raise RuntimeError(message)
+
 client = OpenAI(api_key=OPENAI_API_KEY)
 
 def get_price_url(product: str) -> str:


### PR DESCRIPTION
## Summary
- check for OPENAI_API_KEY in `openai_helper`
- document OPENAI_API_KEY in README
- add OPENAI_API_KEY to sample `.env`

## Testing
- `pre-commit run --files backend/app/services/openai_helper.py .env README.md` *(fails: pre-commit not installed)*
- `bash backend/scripts/test.sh` *(fails: coverage not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68684d4c19dc8323b9a72d3d6dfc2455