### PR TITLE
Add openai dependency

### DIFF
--- a/backend/app/services/openai_helper.py
+++ b/backend/app/services/openai_helper.py
@@ -1,7 +1,7 @@
 # backend/app/services/openai_helper.py
 
 import os
-from openai import OpenAI, ChatCompletion
+from openai import OpenAI
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 client = OpenAI(api_key=OPENAI_API_KEY)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydantic-settings<3.0.0,>=2.2.1",
     "sentry-sdk[fastapi]<2.0.0,>=1.40.6",
     "pyjwt<3.0.0,>=2.8.0",
+    "openai<2.0.0,>=1.0.0",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- install `openai` in backend/pyproject
- clean up unused `ChatCompletion` import

## Testing
- `uv sync` *(fails: Request failed)*
- `uv run pre-commit run --files backend/pyproject.toml backend/app/services/openai_helper.py` *(fails: pre-commit not found)*
- `uv run bash backend/scripts/test.sh` *(fails: coverage not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684d4e4af0832398fb0552ecb84c5f